### PR TITLE
[WIP] Add Channels

### DIFF
--- a/bin/migrate_0.17.0-0.18.0.py
+++ b/bin/migrate_0.17.0-0.18.0.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+import hashlib
+import etcd
+import re
+
+etcd_client = etcd.Client(port=2379)
+ETCD_PREFIX = "kpm/packages/"
+
+
+path = ETCD_PREFIX
+r = {}
+packages = etcd_client.read(path, recursive=True)
+
+for child in packages.children:
+    m = re.match("^/%s(.+?)/(.+?)/(.+?)$" % ETCD_PREFIX, child.key)
+    if m is None:
+        continue
+    organization, name, version = (m.group(1), m.group(2), m.group(3))
+    if len(version.split("/")) > 1:
+        continue
+    package = "%s/%s" % (organization, name)
+    pv = "%s/%s" % (package, version)
+    data = etcd_client.read(ETCD_PREFIX + pv)
+    etcd_client.write(ETCD_PREFIX + package + "/" + "releases" + "/" + version, data.value)
+    etcd_client.delete(ETCD_PREFIX + pv)
+    print "%s/%s" % (package, version)
+
+for child in packages.children:
+    m = re.match("^/%s(.+?)/(.+?)/releases/(.+?)$" % ETCD_PREFIX, child.key)
+    if m is None:
+        continue
+    organization, name, version = (m.group(1), m.group(2), m.group(3))
+    if len(version.split("/")) > 1:
+        continue
+    package = "%s/%s" % (organization, name)
+    pv = "%s/%s" % (package, version)
+    data = etcd_client.read(ETCD_PREFIX + package + "/releases/" + version)
+    print pv
+    sha = hashlib.sha256(data.value).hexdigest()
+    etcd_client.write(ETCD_PREFIX + package + "/" + "digests" + "/" + sha, data.value)
+    print sha

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -1,0 +1,98 @@
+### Releases
+##### List releases in the channel 'stable'
+```
+$ kpm releases ant31/rocketchat --channel stable
+stable: 1.0.0, 1.1.0
+```
+##### List all releases by channels
+```
+$ kpm releases ant31/rocketchat --all-channels
+stable: 1.0.0, 1.1.0
+beta: 1.1.0-beta.3, 1.4.0-beta-2
+dev: 1.5.0-dev, 1.5.0-dev.2
+```
+##### List all releases
+```
+$ kpm releases ant31/rocketchat
+version revision date       digest
+1.0.0   4        2016-08-02 h324052fds
+1.1.0   1        2016-08-01 zs32t45l231
+```
+### Release revision
+##### List all revision for a release
+```
+$ kpm release ant31/rocketchat:v1.1.0
+revision date       current digest
+4        2016-08-02 yes     h3243252f5s
+3        2016-07-31 -       e321266lf2s
+2        2016-06-26 -       a3244366f3s
+1        2016-06-25 -       zs32t45l231
+```
+
+#### Change active revision
+```
+$ kpm release ant31/rocketchat:v1.1.0 --current-revision=3
+revision date       current digest
+4        2016-08-02 -       h3243252f5s
+3        2016-07-31 yes     e321266lf2s
+2        2016-06-26 -       a3244366f3s
+1        2016-06-25 -       zs32t45l231
+```
+### Channels
+
+##### List Channels for a package
+```
+$ kpm channels ant31/rocketchat
+name   releases current       default
+stable 4        v1.2.0        -
+prod   2        v1.1.0        -
+beta   6        v1.4.0-beta.2 yes
+```
+##### Create a new channel
+```
+$ kpm channel ant31/rocketchat -n beta --create
+```
+##### Add/Remove releases
+```
+kpm channel ant31/rocketchat -n beta --releases v1.0.0,v1.1.0,v1.2.0
+kpm channel ant31/rocketchat -n beta --add v1.3.0,v1.4.0
+kpm channel ant31/rocketchat -n beta --remove v1.0.0,v1.1.0
+```
+
+### Deploy
+###### default channel, default release
+`$ kpm deploy ant31/rocketchat`
+###### default channel, select release
+`$ kpm deploy ant31/rocketchat:v1.1.0`
+###### default channel, select release-revision
+`$ kpm deploy ant31/rocketchat:v1.1.0 --revision 2`
+###### Use directly the digest
+`$ kpm deploy ant31/rocketchat@sha256:0ecb2ad60`
+###### stable channel, default release
+`$ kpm deploy ant31/rocketchat --channel stable`
+###### stable channel, select release
+`$ kpm deploy ant31/rocketchat:v1.1.0 --channel stable`
+###### stable channel, release not in the channel
+```
+$ kpm deploy ant31/rocketchat:v1.4.0-beta.2 --channel stable
+--> Error v1.4.0-beta.2 doesn't exist in chan stable
+```
+
+### Push
+##### Push a new release
+```
+kpm push ant31/rocketchat:v1.1.0 [--channels stable,prod,beta]
+--> New release v1.1.0 revision 1 pushed
+```
+##### Push an existing release 
+```
+kpm push ant31/rocketchat:v1.1.0
+--> Error the release v1.1.0 already exist,  use --force
+```
+##### Push an existing release and create a new revision
+```
+kpm push ant31/rocketchat:v1.1.0 --force
+--> Release v1.1.0 updated to revision 2
+```
+
+

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -15,19 +15,26 @@ dev: 1.5.0-dev, 1.5.0-dev.2
 ##### List all releases
 ```
 $ kpm releases ant31/rocketchat
-version revision date       digest
-1.0.0   4        2016-08-02 h324052fds
-1.1.0   1        2016-08-01 zs32t45l231
+version  date       digest
+1.0.0  2016-08-02 h324052fds
+1.1.0  2016-08-01 zs32t45l23
 ```
 ### Channels
 
 ##### List Channels for a package
 ```
-$ kpm channels ant31/rocketchat
+$ kpm channel ant31/rocketchat
 name   releases current       default
 stable 4        v1.2.0        -
 prod   2        v1.1.0        -
 beta   6        v1.4.0-beta.2 yes
+```
+
+```
+$ kpm channel ant31/rocketchat -n stable
+version  date       digest
+1.0.0  2016-08-02 h324052fds
+1.1.0  2016-08-01 zs32t45l23
 ```
 ##### Create a new channel
 ```
@@ -35,9 +42,8 @@ $ kpm channel ant31/rocketchat -n beta --create
 ```
 ##### Add/Remove releases
 ```
-kpm channel ant31/rocketchat -n beta --releases v1.0.0,v1.1.0,v1.2.0
-kpm channel ant31/rocketchat -n beta --add v1.3.0,v1.4.0
-kpm channel ant31/rocketchat -n beta --remove v1.0.0,v1.1.0
+kpm channel ant31/rocketchat -n beta --add v1.3.0
+kpm channel ant31/rocketchat -n beta --remove v1.0.0
 ```
 
 ### Deploy
@@ -67,7 +73,7 @@ kpm push ant31/rocketchat:v1.1.0 [--channels stable,prod,beta]
 --> Added to channels stable,prod and beta
 ```
 
-##### Push an existing release 
+##### Push an existing release
 ```
 kpm push ant31/rocketchat:v1.1.0
 --> Error the release v1.1.0 already exist,  use --force

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -4,6 +4,7 @@
 $ kpm releases ant31/rocketchat --channel stable
 stable: 1.0.0, 1.1.0
 ```
+
 ##### List all releases by channels
 ```
 $ kpm releases ant31/rocketchat --all-channels
@@ -17,26 +18,6 @@ $ kpm releases ant31/rocketchat
 version revision date       digest
 1.0.0   4        2016-08-02 h324052fds
 1.1.0   1        2016-08-01 zs32t45l231
-```
-### Release revision
-##### List all revision for a release
-```
-$ kpm release ant31/rocketchat:v1.1.0
-revision date       current digest
-4        2016-08-02 yes     h3243252f5s
-3        2016-07-31 -       e321266lf2s
-2        2016-06-26 -       a3244366f3s
-1        2016-06-25 -       zs32t45l231
-```
-
-#### Change active revision
-```
-$ kpm release ant31/rocketchat:v1.1.0 --current-revision=3
-revision date       current digest
-4        2016-08-02 -       h3243252f5s
-3        2016-07-31 yes     e321266lf2s
-2        2016-06-26 -       a3244366f3s
-1        2016-06-25 -       zs32t45l231
 ```
 ### Channels
 
@@ -63,18 +44,18 @@ kpm channel ant31/rocketchat -n beta --remove v1.0.0,v1.1.0
 ###### default channel, default release
 `$ kpm deploy ant31/rocketchat`
 ###### default channel, select release
-`$ kpm deploy ant31/rocketchat:v1.1.0`
+`$ kpm deploy ant31/rocketchat@v1.1.0`
 ###### default channel, select release-revision
-`$ kpm deploy ant31/rocketchat:v1.1.0 --revision 2`
+`$ kpm deploy ant31/rocketchat@v1.1.0 --revision 2`
 ###### Use directly the digest
 `$ kpm deploy ant31/rocketchat@sha256:0ecb2ad60`
 ###### stable channel, default release
-`$ kpm deploy ant31/rocketchat --channel stable`
+`$ kpm deploy ant31/rocketchat:stable`
 ###### stable channel, select release
-`$ kpm deploy ant31/rocketchat:v1.1.0 --channel stable`
+`$ kpm deploy ant31/rocketchat@v1.1.0 --in-channel stable`
 ###### stable channel, release not in the channel
 ```
-$ kpm deploy ant31/rocketchat:v1.4.0-beta.2 --channel stable
+$ kpm deploy ant31/rocketchat@v1.4.0-beta.2 --in-channel stable
 --> Error v1.4.0-beta.2 doesn't exist in chan stable
 ```
 
@@ -82,17 +63,12 @@ $ kpm deploy ant31/rocketchat:v1.4.0-beta.2 --channel stable
 ##### Push a new release
 ```
 kpm push ant31/rocketchat:v1.1.0 [--channels stable,prod,beta]
---> New release v1.1.0 revision 1 pushed
+--> New release v1.1.0 pushed
+--> Added to channels stable,prod and beta
 ```
+
 ##### Push an existing release 
 ```
 kpm push ant31/rocketchat:v1.1.0
 --> Error the release v1.1.0 already exist,  use --force
 ```
-##### Push an existing release and create a new revision
-```
-kpm push ant31/rocketchat:v1.1.0 --force
---> Release v1.1.0 updated to revision 2
-```
-
-

--- a/kpm/__init__.py
+++ b/kpm/__init__.py
@@ -24,6 +24,7 @@ def version(registry_host=None):
 
 models_path = {
     'Package': '{models_module}.package:Package',
+    'Channel': '{models_module}.channel:Channel',
 }
 
 models_module = os.getenv('KPM_MODELS_MODULE', "kpm.models.etcd")

--- a/kpm/exception.py
+++ b/kpm/exception.py
@@ -37,6 +37,11 @@ class PackageNotFound(KpmException):
     errorcode = "package-not-found"
 
 
+class ChannelNotFound(KpmException):
+    status_code = 404
+    errorcode = "channel-not-found"
+
+
 class PackageVersionNotFound(KpmException):
     status_code = 404
     errorcode = "package-version-not-found"

--- a/kpm/exception.py
+++ b/kpm/exception.py
@@ -3,7 +3,7 @@ class KpmException(Exception):
     errorcode = "internal-error"
 
     def __init__(self, message, payload=None):
-        Exception.__init__(self)
+        super(KpmException, self).__init__()
         self.payload = dict(payload or ())
         self.message = message
 
@@ -30,6 +30,11 @@ class InvalidVersion(KpmException):
 class PackageAlreadyExists(KpmException):
     status_code = 409
     errorcode = "package-exists"
+
+
+class ChannelAlreadyExists(KpmException):
+    status_code = 409
+    errorcode = "channel-exists"
 
 
 class PackageNotFound(KpmException):

--- a/kpm/models/__init__.py
+++ b/kpm/models/__init__.py
@@ -2,4 +2,12 @@ import sys
 import kpm
 
 
+class Package(object):
+    pass
+
+
+class Channel(object):
+    pass
+
+
 kpm.setup_models(sys.modules[__name__], kpm.models_path, kpm.models_module)

--- a/kpm/models/channel_base.py
+++ b/kpm/models/channel_base.py
@@ -1,0 +1,86 @@
+import datetime
+from kpm.exception import ChannelNotFound
+import kpm.semver as semver
+
+
+class ChannelBase(object):
+    def __init__(self, name, package):
+
+        self.package = package
+        self.name = name
+        self._iscreated = None
+
+    def exists(self):
+        return self._exists()
+
+    def _exists(self):
+        """ Check if the channel is saved already """
+        raise NotImplementedError
+
+    def save(self):
+        raise NotImplementedError
+
+    def delete(self):
+        raise NotImplementedError
+
+    @classmethod
+    def all(self, package):
+        """ Returns all available channels for a package """
+        raise NotImplementedError
+
+    def releases(self):
+        """ Returns the list of versions """
+        raise NotImplementedError
+
+    def _add_release(self, version):
+        # etcdctl put /{self.package/channels/{self.name}/version
+        raise NotImplementedError
+
+    def _remove_release(self, version):
+        # etcdctl put /{self.package/channels/{self.name}/version
+        raise NotImplementedError
+
+    def current_release(self):
+        versions = self.releases()
+        ordered_versions = [str(x) for x in sorted(semver.versions(versions, False),
+                                                   reverse=True)]
+        return ordered_versions[0]
+
+    def activate_release(self, version):
+        raise NotImplementedError
+
+    def add_release(self, version):
+        if self._check_release(version) is False:
+            raise ValueError("Release %s doesn't exist for package %s" % (version, self.package))
+        if not self.exists():
+            self.save()
+        self._add_release(version)
+
+    def remove_release(self, version):
+        if self._check_release(version) is False:
+            raise ValueError("Release %s doesn't exist for package %s" % (version, self.package))
+        if not self.exists():
+            self.save()
+        self._remove_release(version)
+
+    def _check_release(self, release_name):
+        from kpm.models import Package
+        version = Package.get_version(self.package, release_name)
+        if version is None or str(version) != release_name:
+            return False
+        else:
+            return True
+
+    def _new_chan_release(self, version):
+        d = {'release': version,
+             'created_at': datetime.datetime.utcnow().isoformat()}
+        return d
+
+    @classmethod
+    def _raise_not_found(self, package, channel=None, version=None):
+        if channel is None:
+            raise ChannelNotFound("No channel found for package %s" % (package),
+                                  {'package': package})
+        else:
+            raise ChannelNotFound("channel %s doesn't exist for package %s" % (channel, package),
+                                  {'channel': channel, 'package': package, 'version': version})

--- a/kpm/models/etcd/__init__.py
+++ b/kpm/models/etcd/__init__.py
@@ -1,9 +1,14 @@
 import etcd
 import re
 
-etcd_client = etcd.Client(port=2379)
-
 ETCD_PREFIX = "kpm/packages/"
+
+
+class EtcdClient(etcd.client.Client):
+    pass
+
+
+etcd_client = EtcdClient(port=2379)
 
 
 def etcd_listkeys(key, path):

--- a/kpm/models/etcd/__init__.py
+++ b/kpm/models/etcd/__init__.py
@@ -1,5 +1,16 @@
 import etcd
+import re
 
 etcd_client = etcd.Client(port=2379)
 
 ETCD_PREFIX = "kpm/packages/"
+
+
+def etcd_listkeys(key, path):
+    result = []
+    for child in key.children:
+        m = re.match("^/%s/(.+)$" % path, child.key)
+        if m is None:
+            continue
+        result.append(m.group(1))
+    return result

--- a/kpm/models/etcd/channel.py
+++ b/kpm/models/etcd/channel.py
@@ -1,6 +1,7 @@
+import re
 import etcd
 from kpm.models.channel_base import ChannelBase
-from kpm.models.etcd import etcd_client, etcd_listkeys, ETCD_PREFIX
+from kpm.models.etcd import etcd_listkeys, ETCD_PREFIX, etcd_client
 
 
 class Channel(ChannelBase):
@@ -26,24 +27,35 @@ class Channel(ChannelBase):
     def save(self):
         path = self._etcdpath(self.package, self.name)
         try:
-            etcd_client.write(path, None,  dir=True)
+            etcd_client.write(path, None,  dir=True, prevExist=False)
+            return True
         except etcd.EtcdAlreadyExist:
-            pass
+            raise self._raise_already_exists(self.name, self.package)
 
     def delete(self):
         path = self._etcdpath(self.package, self.name)
         if self.exists:
             etcd_client.delete(path, recursive=True)
+            return True
+        return False
 
     @classmethod
-    def all(self, package):
-        """ Returns all available channels for a package """
+    def _all(self, package):
+        """
+        Returns all available channels for a package
+        """
         path = self._etcdpath(package)
         try:
             chans = etcd_client.read(path, recursive=True)
         except etcd.EtcdKeyNotFound:
             self._raise_not_found(package)
-        result = etcd_listkeys(chans, path)
+        result = []
+        for child in chans.children:
+            m = re.match("^/%s/([a-zA-Z0-9-_]+)/?.*$" % path, child.key)
+            if m is None:
+                continue
+            channel = m.group(1)
+            result.append(channel)
         return result
 
     def releases(self):
@@ -52,23 +64,26 @@ class Channel(ChannelBase):
         try:
             releases = etcd_client.read(path, recursive=True)
         except etcd.EtcdKeyNotFound:
-            self._raise_not_found(self.name, self.package)
+            self._raise_not_found(self.package, self.name)
         result = etcd_listkeys(releases, path)
         return result
 
     def _add_release(self, version):
         path = self._etcdpath(self.package, "%s/%s" % (self.name, version))
         try:
-            etcd_client.write(path, self._new_chan_release(version), prevExist=False)
+            n = self._new_chan_release(version)
+            etcd_client.write(path, n, prevExist=False)
         except etcd.EtcdAlreadyExist:
-            pass
+            raise self._raise_already_exists(self.name, self.package, version)
+        return n
 
     def _remove_release(self, version):
         path = self._etcdpath(self.package, "%s/%s" % (self.name, version))
         try:
             etcd_client.delete(path)
+            return True
         except etcd.EtcdKeyNotFound:
-            self._raise_not_found(self.name, self.package, version)
+            self._raise_not_found(self.package, self.name, version)
 
     def activate_release(self, version):
         raise NotImplementedError

--- a/kpm/models/etcd/channel.py
+++ b/kpm/models/etcd/channel.py
@@ -1,0 +1,74 @@
+import etcd
+from kpm.models.channel_base import ChannelBase
+from kpm.models.etcd import etcd_client, etcd_listkeys, ETCD_PREFIX
+
+
+class Channel(ChannelBase):
+    def __init__(self, name, package):
+        super(Channel, self).__init__(name, package)
+
+    @classmethod
+    def _etcdpath(self, package, name=None):
+        path = ETCD_PREFIX + package + "/channels"
+        if name is not None:
+            path = path + "/%s" % name
+        return path
+
+    def _exists(self):
+        """ Check if the channel is saved already """
+        path = self._etcdpath(self.package, self.name)
+        try:
+            etcd_client.read(path)
+        except etcd.EtcdKeyNotFound:
+            return False
+        return True
+
+    def save(self):
+        path = self._etcdpath(self.package, self.name)
+        try:
+            etcd_client.write(path, None,  dir=True)
+        except etcd.EtcdAlreadyExist:
+            pass
+
+    def delete(self):
+        path = self._etcdpath(self.package, self.name)
+        if self.exists:
+            etcd_client.delete(path, recursive=True)
+
+    @classmethod
+    def all(self, package):
+        """ Returns all available channels for a package """
+        path = self._etcdpath(package)
+        try:
+            chans = etcd_client.read(path, recursive=True)
+        except etcd.EtcdKeyNotFound:
+            self._raise_not_found(package)
+        result = etcd_listkeys(chans, path)
+        return result
+
+    def releases(self):
+        """ Returns the list of versions """
+        path = self._etcdpath(self.package, self.name)
+        try:
+            releases = etcd_client.read(path, recursive=True)
+        except etcd.EtcdKeyNotFound:
+            self._raise_not_found(self.name, self.package)
+        result = etcd_listkeys(releases, path)
+        return result
+
+    def _add_release(self, version):
+        path = self._etcdpath(self.package, "%s/%s" % (self.name, version))
+        try:
+            etcd_client.write(path, self._new_chan_release(version), prevExist=False)
+        except etcd.EtcdAlreadyExist:
+            pass
+
+    def _remove_release(self, version):
+        path = self._etcdpath(self.package, "%s/%s" % (self.name, version))
+        try:
+            etcd_client.delete(path)
+        except etcd.EtcdKeyNotFound:
+            self._raise_not_found(self.name, self.package, version)
+
+    def activate_release(self, version):
+        raise NotImplementedError

--- a/kpm/models/etcd/package.py
+++ b/kpm/models/etcd/package.py
@@ -3,7 +3,7 @@ import kpm.semver as semver
 import re
 from kpm.models.package_base import PackageModelBase
 from kpm.exception import PackageAlreadyExists
-from kpm.models.etcd import etcd_client, ETCD_PREFIX
+from kpm.models.etcd import ETCD_PREFIX, etcd_client
 
 
 class Package(PackageModelBase):
@@ -14,7 +14,7 @@ class Package(PackageModelBase):
     def _fetch(self, package, version):
         path = self._etcdkey(package, str(version))
         try:
-            package_data = etcd_client.read(path)
+            package_data = etcd_client.read(path).value
         except etcd.EtcdKeyNotFound:
             self._raise_not_found(package, version)
         return package_data

--- a/kpm/models/etcd/package.py
+++ b/kpm/models/etcd/package.py
@@ -21,7 +21,7 @@ class Package(PackageModelBase):
 
     @classmethod
     def all_versions(self, package):
-        path = ETCD_PREFIX + package
+        path = ETCD_PREFIX + package + "/releases"
         try:
             r = etcd_client.read(path, recursive=True)
         except etcd.EtcdKeyNotFound:
@@ -45,7 +45,7 @@ class Package(PackageModelBase):
             etcd_client.write(path, None, dir=True)
 
         for child in packages.children:
-            m = re.match("^/%s(.+)/(.+)/(.+)$" % ETCD_PREFIX, child.key)
+            m = re.match("^/%s(.+)/(.+)/releases/(.+)$" % ETCD_PREFIX, child.key)
             if m is None:
                 continue
             organization, name, version = (m.group(1), m.group(2), m.group(3))
@@ -61,14 +61,14 @@ class Package(PackageModelBase):
         return r.values()
 
     def _save(self, force=False):
-        self._push_etcd(self.name, self.version, self.blob, force=force)
+        self._push_etcd(self.package, self.version, self.blob, force=force)
 
     def delete(self):
         raise NotImplementedError
 
     @classmethod
     def _etcdkey(self, package, version):
-        return ETCD_PREFIX + "%s/%s" % (package, version)
+        return ETCD_PREFIX + "%s/releases/%s" % (package, version)
 
     def _push_etcd(self, package, version, data, force=False):
         path = self._etcdkey(package, version)

--- a/kpm/registry.py
+++ b/kpm/registry.py
@@ -133,3 +133,29 @@ class Registry(object):
         r = requests.delete(self._url(path), params=params, headers=self.headers)
         r.raise_for_status()
         return True
+
+    def _crud_channel(self, name, channel='', action='get'):
+        path = "/packages/%s/channels/%s" % (name, channel)
+        r = getattr(requests, action)(self._url(path), params={}, headers=self.headers)
+        r.raise_for_status()
+        return r.json()
+
+    def list_channels(self, name):
+        return self._crud_channel(name)
+
+    def show_channel(self, name, channel):
+        return self._crud_channel(name, channel)
+
+    def create_channel(self, name, channel):
+        return self._crud_channel(name, channel, 'post')
+
+    def delete_channel(self, name, channel):
+        return self._crud_channel(name, channel, 'delete')
+
+    def create_channel_release(self, name, channel, release):
+        path = "%s/%s" % (channel, release)
+        return self._crud_channel(name, path, 'post')
+
+    def delete_channel_release(self, name, channel, release):
+        path = "%s/%s" % (channel, release)
+        return self._crud_channel(name, path, 'delete')

--- a/migrations/migrate_0.17.0-0.18.0.py
+++ b/migrations/migrate_0.17.0-0.18.0.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+import hashlib
+import etcd
+import re
+
+etcd_client = etcd.Client(port=2379)
+ETCD_PREFIX = "kpm/packages/"
+
+
+path = ETCD_PREFIX
+r = {}
+packages = etcd_client.read(path, recursive=True)
+
+for child in packages.children:
+    m = re.match("^/%s(.+?)/(.+?)/(.+?)$" % ETCD_PREFIX, child.key)
+    if m is None:
+        continue
+    organization, name, version = (m.group(1), m.group(2), m.group(3))
+    if len(version.split("/")) > 1:
+        continue
+    package = "%s/%s" % (organization, name)
+    pv = "%s/%s" % (package, version)
+    data = etcd_client.read(ETCD_PREFIX + pv)
+    etcd_client.write(ETCD_PREFIX + package + "/" + "releases" + "/" + version, data.value)
+    etcd_client.delete(ETCD_PREFIX + pv)
+    print "%s/%s" % (package, version)
+
+for child in packages.children:
+    m = re.match("^/%s(.+?)/(.+?)/releases/(.+?)$" % ETCD_PREFIX, child.key)
+    if m is None:
+        continue
+    organization, name, version = (m.group(1), m.group(2), m.group(3))
+    if len(version.split("/")) > 1:
+        continue
+    package = "%s/%s" % (organization, name)
+    pv = "%s/%s" % (package, version)
+    data = etcd_client.read(ETCD_PREFIX + package + "/releases/" + version)
+    print pv
+    sha = hashlib.sha256(data.value).hexdigest()
+    etcd_client.write(ETCD_PREFIX + package + "/" + "digests" + "/" + sha, data.value)
+    print sha

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,8 @@ setup(
     packages=[
         'kpm',
         'kpm.api',
-        'kpm.models'
+        'kpm.models',
+        'kpm.models.etcd'
     ],
     scripts=[
         'bin/kpm'

--- a/tests/api/test_api_registry.py
+++ b/tests/api/test_api_registry.py
@@ -39,7 +39,7 @@ def test_showversion(client):
 
 
 def test_etcdkey():
-    assert models.Package._etcdkey("a/b", "1.4.3") == "kpm/packages/a/b/1.4.3"
+    assert models.Package._etcdkey("a/b", "1.4.3") == "kpm/packages/a/b/releases/1.4.3"
 
 
 def test_check_data_validversion():
@@ -54,13 +54,13 @@ def test_check_data_invalidversion():
 @pytest.fixture()
 def getversions(monkeypatch):
     def read(path, recursive=True):
-        assert path == "kpm/packages/ant31/rocketchat"
-        return MockEtcdResults(["kpm/packages/ant31/rocketchat/1.3.0",
-                                "kpm/packages/ant31/rocketchat/1.3.2-rc2",
-                                "kpm/packages/ant31/rocketchat/1.8.2-rc2",
-                                "kpm/packages/ant31/rocketchat/1.4.2",
-                                "kpm/packages/ant31/rocketchat/1.0.0",
-                                "kpm/packages/ant31/rocketchat/1.2.0"])
+        assert path == "kpm/packages/ant31/rocketchat/releases"
+        return MockEtcdResults(["kpm/packages/ant31/rocketchat/releases/1.3.0",
+                                "kpm/packages/ant31/rocketchat/releases/1.3.2-rc2",
+                                "kpm/packages/ant31/rocketchat/releases/1.8.2-rc2",
+                                "kpm/packages/ant31/rocketchat/releases/1.4.2",
+                                "kpm/packages/ant31/rocketchat/releases/1.0.0",
+                                "kpm/packages/ant31/rocketchat/releases/1.2.0"])
     monkeypatch.setattr("kpm.models.etcd.etcd_client.read", read)
 
 
@@ -70,7 +70,7 @@ def test_getversions(getversions):
 
 def test_getversions_empty(monkeypatch):
     def read(path, recursive=True):
-        assert path == "kpm/packages/ant31/rocketchat"
+        assert path == "kpm/packages/ant31/rocketchat/releases"
         return MockEtcdResults([])
     monkeypatch.setattr("kpm.models.etcd.etcd_client.read", read)
     assert models.Package.all_versions("ant31/rocketchat") == []
@@ -95,7 +95,7 @@ def test_getversion_prerelease(getversions):
 
 def test_push_etcd(monkeypatch):
     def write(path, data, prevExist):
-        assert path == "kpm/packages/a/b/4"
+        assert path == "kpm/packages/a/b/releases/4"
         assert data == "value"
         return True
     monkeypatch.setattr("kpm.models.etcd.etcd_client.write", write)
@@ -105,7 +105,7 @@ def test_push_etcd(monkeypatch):
 
 def test_push_etcd_exist(monkeypatch):
     def write(path, data, prevExist):
-        assert path == "kpm/packages/a/b/4"
+        assert path == "kpm/packages/a/b/releases/4"
         assert data == "value"
         raise etcd.EtcdAlreadyExist
     monkeypatch.setattr("kpm.models.etcd.etcd_client.write", write)


### PR DESCRIPTION
### Channels
Channels allow to organize workflows, life cycle of a package and fine-grained permission control 

- development, beta, rc, production
- unstable, stable
- stable-v2, stable-v3

A channel contains a list of Package release, exactly one of the release is marked as active

## UX

### Releases
##### List releases in the channel 'stable'
```
$ kpm releases ant31/rocketchat --channel stable
stable: 1.0.0, 1.1.0
```

##### List all releases by channels
```
$ kpm releases ant31/rocketchat --all-channels
stable: 1.0.0, 1.1.0
beta: 1.1.0-beta.3, 1.4.0-beta-2
dev: 1.5.0-dev, 1.5.0-dev.2
```
##### List all releases
```
$ kpm releases ant31/rocketchat
version revision date       digest
1.0.0   4        2016-08-02 h324052fds
1.1.0   1        2016-08-01 zs32t45l231
```
### Channels

##### List Channels for a package
```
$ kpm channels ant31/rocketchat
name   releases current       default
stable 4        v1.2.0        -
prod   2        v1.1.0        -
beta   6        v1.4.0-beta.2 yes
```
##### Create a new channel
```
$ kpm channel ant31/rocketchat -n beta --create
```
##### Add/Remove releases
```
kpm channel ant31/rocketchat -n beta --releases v1.0.0,v1.1.0,v1.2.0
kpm channel ant31/rocketchat -n beta --add v1.3.0,v1.4.0
kpm channel ant31/rocketchat -n beta --remove v1.0.0,v1.1.0
```

### Deploy
###### default channel, default release
`$ kpm deploy ant31/rocketchat`
###### default channel, select release
`$ kpm deploy ant31/rocketchat@v1.1.0`
###### default channel, select release-revision
`$ kpm deploy ant31/rocketchat@v1.1.0 --revision 2`
###### Use directly the digest
`$ kpm deploy ant31/rocketchat@sha256:0ecb2ad60`
###### stable channel, default release
`$ kpm deploy ant31/rocketchat:stable`
###### stable channel, select release
`$ kpm deploy ant31/rocketchat@v1.1.0 --in-channel stable`
###### stable channel, release not in the channel
```
$ kpm deploy ant31/rocketchat@v1.4.0-beta.2 --in-channel stable
--> Error v1.4.0-beta.2 doesn't exist in chan stable
```

### Push
##### Push a new release
```
kpm push ant31/rocketchat@v1.1.0 [--channels stable,prod,beta]
--> New release v1.1.0 pushed
--> Added to channels stable,prod and beta
```

##### Push an existing release 
```
kpm push ant31/rocketchat@v1.1.0
--> Error the release v1.1.0 already exist,  use --force
```