### PR TITLE
Prevent generated templates from being wrapped

### DIFF
--- a/kpm/kub.py
+++ b/kpm/kub.py
@@ -109,7 +109,7 @@ class Kub(KubBase):
             else:
                 tpl_file = resource['file']
             if from_value or resource.get('generated', False) is True:
-                val = yaml.safe_dump(convert_utf8(resource['value']))
+                val = yaml.safe_dump(convert_utf8(resource['value']), width=float("inf"))
             else:
                 val = self.package.files[os.path.join('templates', tpl_file)]
             template = jinja_env.from_string(val)


### PR DESCRIPTION
Before this patch, on the second rendering pass, lines still containing templating tags (i.e. `{% raw %}{{ .IP }}{% endraw %}`) could be wrapped (see below), thus preventing proper Jinja parsing. 

```
[...] {%\
    \ raw %}{{ .IP }}{% endraw %}
```

```
File "/kpm-source/kpm/kpm/kub.py", line 156, in resources
    resources = self._resolve_jinja(resources, True)
  File "/kpm-source/kpm/kpm/kub.py", line 117, in _resolve_jinja
    template = jinja_env.from_string(val)
  File "/usr/local/lib/python2.7/dist-packages/jinja2/environment.py", line 862, in from_string
    return cls.from_code(self, self.compile(source), globals, None)
  File "/usr/local/lib/python2.7/dist-packages/jinja2/environment.py", line 565, in compile
    self.handle_exception(exc_info, source_hint=source_hint)
  File "/usr/local/lib/python2.7/dist-packages/jinja2/environment.py", line 754, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "<unknown>", line 2, in template
TemplateSyntaxError: unexpected char u'\\' at 96
```