### PR TITLE
[Jsonnet] MergePatch variables (fix)

### DIFF
--- a/kpm/jsonnet/lib/kpm.libjsonnet
+++ b/kpm/jsonnet/lib/kpm.libjsonnet
@@ -6,7 +6,7 @@ kpmstd {
 
    variables(package, params):: (
    local p = package + {variables: package.variables + std.mergePatch(super.variables, params.variables)};
-     p
+     p.variables
    ),
 
    deploy(dep):: (


### PR DESCRIPTION
Variables have to be returned, not the package itself.