### PR TITLE
Authorize *.yaml/AUTHORS/NOTICE files in packages

### DIFF
--- a/kpm/packager.py
+++ b/kpm/packager.py
@@ -25,9 +25,11 @@ logger = logging.getLogger(__name__)
 #
 AUTHORIZED_FILES = ["*.libjsonnet",
                     "*.jsonnet",
+                    "*.yaml",
                     "README.md",
-                    "manifest.yaml",
                     "LICENSE",
+                    "AUTHORS",
+                    "NOTICE",
                     "deps/*.kub"]
 
 

--- a/tests/test_packager.py
+++ b/tests/test_packager.py
@@ -16,7 +16,7 @@ def _check_kub(path):
     for f in KUBEUI_FILES:
         assert os.path.exists(os.path.join(str(path), f))
     assert os.path.exists(os.path.join(str(path), "templates/another_file_to_ignore.cfg")) is False
-    assert os.path.exists(os.path.join(str(path), "file_to_ignore.yaml")) is False
+    assert os.path.exists(os.path.join(str(path), "file_to_ignore")) is False
 
 
 def test_pack_kub_with_authorized_only(pack_tar, tmpdir):


### PR DESCRIPTION
Convenient to use `variables: kpmstd.yamlLoads(importstr "parameters.yaml")` for instance.