### PR TITLE
Fix some references to old repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ $ sudo pip install kpm -U
 ##### From git
 
 ```
-git clone https://github.com/kubespray/kpm.git kpm-cli
+git clone https://github.com/coreos/kpm.git kpm-cli
 cd kpm-cli
 sudo make install
 ```

--- a/docs/package-discovery.md
+++ b/docs/package-discovery.md
@@ -6,7 +6,7 @@ When this format is used to reference a package, the package must be stored and 
 This can quickly become an issue as different registries will appear and packages may move from one to an another or a dependency list refer to packages that exist in differents registries only.
 Another point: with the default format there is no source mirror.
 
-To solve this, as suggested in [issue#28](https://github.com/kubespray/kpm/issues/28) KPM has a discovery process to retrieve the sources of a package.
+To solve this, as suggested in [issue#28](https://github.com/coreos/kpm/issues/28) KPM has a discovery process to retrieve the sources of a package.
 
 To use this discovery feature, a package must have a URL-like structure: `example.com/name`.
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     long_description=readme + '\n\n' + history,
     author="Antoine Legrand",
     author_email='2t.antoine@gmail.com',
-    url='https://github.com/kubespray/kpm',
+    url='https://github.com/coreos/kpm',
     packages=[
         'kpm',
         'kpm.api',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ def discovery_html():
     <meta name="kpm-package" content="kpm.sh/{name} https://api.kubespray.io/api/v1/packages/{name}/pull">
     </head>
     <body>
-    <a href=https://github.com/kubespray/kpm>kubespray/kpm</a>
+    <a href=https://github.com/coreos/kpm>coreos/kpm</a>
     </body>
     </html>"""
 


### PR DESCRIPTION
As I was reading stuff I noticed a few things referencing the old repo.