### PR TITLE
deploy: remove cpu from kpm-registry

### DIFF
--- a/deploy/kpm-registry/templates/kpm-registry-dp.yaml
+++ b/deploy/kpm-registry/templates/kpm-registry-dp.yaml
@@ -31,10 +31,6 @@ spec:
         - name: kpm-registry
           image: {{image}}
           imagePullPolicy: Always
-          resources:
-            limits:
-              cpu: 1
-#              memory: 6Gi
           env:
             - name: KPM_URI
               value: {{kpm_uri}}


### PR DESCRIPTION
With this a minikube instance cannot deploy kpm-registry. After removing
it everything works.